### PR TITLE
update sentence framing to assert optionality over mandatory absence

### DIFF
--- a/Week-2/Lecture5.md
+++ b/Week-2/Lecture5.md
@@ -55,7 +55,7 @@ read varname <&"${NAME[0]}"
 	
 * Run command `sleep 10` as a coprocess.
 	- command run within the same shell.
-	- process name can not be given.
+	- process name can be not given.
 	- default name is used.
 ```terminal
 ~$ coproc sleep 10


### PR DESCRIPTION
`can not be given` implies it is not possible to give a name. 

`can be not given` implies that it is also possible to omit it.